### PR TITLE
Match the error message to the tested file

### DIFF
--- a/fix-wordpress-permissions.sh
+++ b/fix-wordpress-permissions.sh
@@ -27,5 +27,5 @@ if [ -f ${WP_ROOT}/wp-load.php ]; then
   find ${WP_ROOT}/wp-content -type d -exec chmod 775 {} \;
   find ${WP_ROOT}/wp-content -type f -exec chmod 664 {} \;
 else
-  echo "wp-config.php now found, "
+  echo "${WP_ROOT}/wp-load.php not found"
 fi


### PR DESCRIPTION
I noticed you were testing for wp-load and reporting wp-config not found.